### PR TITLE
Add flake8 config

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,0 +1,2 @@
+[flake8]
+ignore=D100,D101,D102,D103


### PR DESCRIPTION
Submitted for the approval of the midnight society:

Python is a bit of a special case since it has "official" linting rules (established via PEPs like [PEP8](https://www.python.org/dev/peps/pep-0008/) and [PEP257](https://www.python.org/dev/peps/pep-0257/)).

Still, I think we might want to ignore some rules and, besides, having the file in the repo to let everybody know what linter we use and what we expect is good!

So this setup.cfg establishes that we use [flake8](https://pypi.python.org/pypi/flake8) and ignores D10X rules (docstrings required on everything) from the [flake8-docstrings](https://pypi.python.org/pypi/flake8-docstrings) extension.

I'd like to find a way to say that we require [flake8-docstrings](https://pypi.python.org/pypi/flake8-docstrings) and [pep8-naming](https://pypi.python.org/pypi/pep8-naming) but I haven't figured out a way [yet](http://stackoverflow.com/questions/28566313/require-flake8-extensions-in-setup-cfg).
