### PR TITLE
Ignoring pep8 line length requirements

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -1,2 +1,2 @@
 [flake8]
-ignore=D100,D101,D102,D103
+ignore=D100,D101,D102,D103,E501


### PR DESCRIPTION
This has been discussed. Adding it here for further discussion.

We could also establish a custom line length by adding like this property:

```
max-line-length = 160
```
