### PR TITLE
Remove func-style until we can exempt arrow funcs

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,7 +23,6 @@
     "comma-style": [2, "last"],
     "consistent-this": [2, "self"],
     "curly": [2, "multi-line"],
-    "func-style": [2, "declaration"],
     "quote-props": [2, "as-needed"],
     "quotes": [2, "single", "avoid-escape"],
     "space-after-function-name": [2, "never"],


### PR DESCRIPTION
Related: eslint/eslint#1897
