### PR TITLE
Don't require new with capitalized functions

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,6 +23,7 @@
     "comma-style": [2, "last"],
     "consistent-this": [2, "self"],
     "curly": [2, "multi-line"],
+    "new-cap": [2, {"newIsCap": true, "capIsNew": false}],
     "quote-props": [2, "as-needed"],
     "quotes": [2, "single", "avoid-escape"],
     "space-after-function-name": [2, "never"],


### PR DESCRIPTION
With widespread agreement that [new is bad](https://www.google.com/search?q=javascript+new+considered+harmful), "newless constructors" and
capitalized factory functions have become pretty common (e.g. [Immutable.js](http://facebook.github.io/immutable-js/docs/)).
