### PR TITLE
Don't enforce consistent returns

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -22,6 +22,7 @@
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],
     "comma-style": [2, "last"],
     "consistent-this": [2, "self"],
+    "consistent-return": 0,
     "curly": [2, "multi-line"],
     "quote-props": [2, "as-needed"],
     "quotes": [2, "single", "avoid-escape"],


### PR DESCRIPTION
Enforcing consistent returns prevents us from using guards, which is a
style we like.
