### PR TITLE
Update generator-star rule

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -39,7 +39,7 @@
     "yoda": [2, "never"],
 
     "no-var": 2,
-    "generator-star": [2, "start"],
+    "generator-star-spacing": [2, "before"],
 
     "react/jsx-boolean-value": [2, "never"],
     "react/jsx-quotes": [2, "double", "avoid-escape"],


### PR DESCRIPTION
The `generator-star` rule has been deprecated in favor of `generator-star-spacing`.

I've also changed the value for this one. This was one of the rules where I couldn't really find a good standard so I just picked something at random, but eslint has chosen "before" as their default so I figure we should just adopt that.
