### PR TITLE
Require strictness

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -16,7 +16,7 @@
   },
 
   "rules": {
-    "strict": 0,
+    "strict": [2, "global"],
 
     "comma-dangle": [2, "always-multiline"],
     "no-floating-decimal": 2,


### PR DESCRIPTION
This shouldn’t require unnecessary “use strict” statements (i.e. when
using modules).
