### PR TITLE
Validate jsdoc

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -42,6 +42,12 @@
     "no-var": 2,
     "generator-star-spacing": [2, "before"],
 
+    "valid-jsdoc": [2, {
+      "prefer": {
+        "return": "returns"
+      }
+    }],
+
     "react/jsx-boolean-value": [2, "never"],
     "react/jsx-quotes": [2, "double", "avoid-escape"],
     "react/jsx-uses-vars": 1,


### PR DESCRIPTION
This doesn't force us to use jsdoc, but it makes sure it's valid when we do.

Getting better about documentation would be nice.
