### PR TITLE
Allow everything to be used before it's defined

### DIFF
--- a/JavaScript (eslint)/.eslintrc
+++ b/JavaScript (eslint)/.eslintrc
@@ -21,7 +21,7 @@
 
     "comma-dangle": [2, "always-multiline"],
     "no-floating-decimal": 2,
-    "no-use-before-define": [2, "nofunc"],
+    "no-use-before-define": 0,
 
     "indent": [2, 2, {"indentSwitchCase": true}],
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],


### PR DESCRIPTION
[Previously](https://github.com/hzdg/linter-configs/pull/10), we decided to allow this for functions…but maybe we should just allow it for everything.

This gives us more control over source order. For example, we can define a React component (that uses a style object) before the style object. Or have multiple components in a single module and put the primary one first and the ones it uses after.
