### PR TITLE
1.0 rules

### DIFF
--- a/JavaScript (eslint)/.eslintrc
+++ b/JavaScript (eslint)/.eslintrc
@@ -25,7 +25,7 @@
 
     "indent": [2, 2, {"SwitchCase": 1}],
     "brace-style": [2, "1tbs", {"allowSingleLine": true}],
-    "callback-return": 0,
+    "callback-return": 2,
     "comma-style": [2, "last"],
     "consistent-this": [2, "self"],
     "consistent-return": 0,


### PR DESCRIPTION
This PR migrates some removed rules to their new counterparts, and adds the following new rules which didn't exist before:

Enabled:
- ~~arrow-parens~~
- [arrow-spacing](http://eslint.org/docs/1.0.0/rules/arrow-spacing) (before and after)
- [callback-return](http://eslint.org/docs/1.0.0/rules/callback-return)
- [no-class-assign](http://eslint.org/docs/1.0.0/rules/no-class-assign)
- [no-const-assign](http://eslint.org/docs/1.0.0/rules/no-const-assign)
- [no-useless-call](http://eslint.org/docs/1.0.0/rules/no-useless-call)
- [prefer-spread](http://eslint.org/docs/1.0.0/rules/prefer-spread)
- ~~require-yield~~

Disabled:
- [arrow-parens](http://eslint.org/docs/1.0.0/rules/arrow-parens)
- ~~callback-return~~
- [init-declarations](http://eslint.org/docs/1.0.0/rules/init-declarations)
- [require-yield](http://eslint.org/docs/1.0.0/rules/require-yield)
