### PR TITLE
Allow extra parens

### DIFF
--- a/JavaScript (eslint)/.eslintrc
+++ b/JavaScript (eslint)/.eslintrc
@@ -97,7 +97,7 @@
     "no-extend-native": 2,
     "no-extra-bind": 2,
     "no-extra-boolean-cast": 2,
-    "no-extra-parens": 2,
+    "no-extra-parens": 0,
     "no-extra-semi": 2,
     "no-fallthrough": 2,
     "no-func-assign": 2,


### PR DESCRIPTION
Not allowing this breaks on the returned expression on render in react components.
